### PR TITLE
Uses the correct class attribute

### DIFF
--- a/movement_primitives/dmp/_cartesian_dmp.py
+++ b/movement_primitives/dmp/_cartesian_dmp.py
@@ -195,7 +195,7 @@ class CartesianDMP(DMPBase):
         weights : array, shape (6 * n_weights_per_dim,)
             Current weights of the DMP.
         """
-        return np.concatenate(self.forcing_term.weights_pos.ravel(),
+        return np.concatenate(self.forcing_term_pos.weights.ravel(),
                               self.forcing_term_rot.weights.ravel())
 
     def set_weights(self, weights):


### PR DESCRIPTION
This PR should solve issue #3 by correcting the class attribute call in the `get_weights()` function.