### PR TITLE
Modify the initial method of T in dmp_open_loop_quaternion() to avoid numerical rounding errors

### DIFF
--- a/movement_primitives/dmp/_cartesian_dmp.py
+++ b/movement_primitives/dmp/_cartesian_dmp.py
@@ -583,4 +583,5 @@ def dmp_open_loop_quaternion(
             int_dt=int_dt)
         #T.append(t)
         Y.append(np.copy(y))
-    return np.asarray(T), np.asarray(Y)
+    #return np.asarray(T), np.asarray(Y)
+    return T, np.asarray(Y)

--- a/movement_primitives/dmp/_cartesian_dmp.py
+++ b/movement_primitives/dmp/_cartesian_dmp.py
@@ -563,15 +563,17 @@ def dmp_open_loop_quaternion(
     t = start_t
     y = np.copy(start_y)
     yd = np.zeros(3)
-    T = [start_t]
+    #T = [start_t]
     Y = [np.copy(y)]
     if run_t is None:
         run_t = goal_t
-    while t < run_t:
-        last_t = t
-        t += dt
-        quaternion_step_function(
-            last_t, t, y, yd,
+    T = np.arange(start_t, run_t+dt, dt)
+    #while t < run_t:
+        #last_t = t
+        #t += dt
+    for i in range(1,len(T)):
+        quaternion_step_function( #last_t, t, y, yd,
+            T[i-1], T[i], y, yd,
             goal_y=goal_y, goal_yd=np.zeros_like(yd),
             goal_ydd=np.zeros_like(yd),
             start_y=start_y, start_yd=np.zeros_like(yd),
@@ -579,6 +581,6 @@ def dmp_open_loop_quaternion(
             goal_t=goal_t, start_t=start_t, alpha_y=alpha_y, beta_y=beta_y,
             forcing_term=forcing_term, coupling_term=coupling_term,
             int_dt=int_dt)
-        T.append(t)
+        #T.append(t)
         Y.append(np.copy(y))
     return np.asarray(T), np.asarray(Y)


### PR DESCRIPTION
the origin initial method  about T in ``dmp_open_loop_quaternion()`` is:`T = [start_t]; while t <run_t: last_t=t, t+=dt,T.append(t)`, which will cause the numerical rounding errors when run_t = 2.99. In detail: when t = 2.07, ``t+= dt`` t should be 2.08, but is the real scene, it will become 2.0799999999. And it will cause the length of Yr becomes 301. In the End, I am greenhand about Github, I am sorry if I do something wrong operation about repo.