### PR TITLE
Expose alpha_y, beta_y parameters

### DIFF
--- a/examples/plot_dmp_2d_gain.py
+++ b/examples/plot_dmp_2d_gain.py
@@ -6,12 +6,13 @@ Effect of DMP Gain
 Demonstrates how modifying DMP gains (alpha_y, beta_y) affects 
 the resulting trajectory reproduction.
 """
-
 print(__doc__)
+
 
 import matplotlib.pyplot as plt
 import numpy as np
 from movement_primitives.dmp import DMP
+
 
 dt = 0.01
 

--- a/examples/plot_dmp_2d_gain.py
+++ b/examples/plot_dmp_2d_gain.py
@@ -1,0 +1,60 @@
+"""
+==================
+Effect of DMP Gain
+==================
+
+Demonstrates how modifying DMP gains (alpha_y, beta_y) affects 
+the resulting trajectory reproduction.
+
+
+"""
+
+print(__doc__)
+
+import matplotlib.pyplot as plt
+import numpy as np
+from movement_primitives.dmp import DMP
+
+dt = 0.01
+
+dmp1 = DMP(
+    n_dims=2,
+    execution_time=1.0,
+    dt=dt,
+    n_weights_per_dim=10,
+    int_dt=0.0001,
+    alpha_y=np.array([25.0, 25.0]),
+    beta_y=np.array([6.25, 6.25]),
+)
+
+dmp2 = DMP(
+    n_dims=2,
+    execution_time=1.0,
+    dt=dt,
+    n_weights_per_dim=10,
+    int_dt=0.0001,
+    alpha_y=np.array([25.0, 10.0]),  # note different alpha_y
+    beta_y=np.array([6.25, 3.0]),  # note different beta_y
+)
+
+T = np.linspace(0.0, 1.0, 101)
+Y = np.empty((101, 2))
+Y[:, 0] = np.cos(np.pi * T)
+Y[:, 1] = np.sin(np.pi * T)
+
+plt.plot(Y[:, 0], Y[:, 1], label="Demo")
+dmps = [dmp1, dmp2]
+for i, dmp in enumerate(dmps):
+
+    dmp.imitate(T, Y)
+    dmp.configure(start_y=Y[0], goal_y=Y[-1])
+    _, Y_ = dmp.open_loop()
+    plt.plot(Y_[:, 0], Y_[:, 1], label=f"Reproduction {i+1}")
+
+plt.grid()
+plt.gca().set_aspect("equal", "box")
+plt.legend()
+plt.xlabel("x")
+plt.ylabel("y")
+
+plt.show()

--- a/examples/plot_dmp_2d_gain.py
+++ b/examples/plot_dmp_2d_gain.py
@@ -5,8 +5,6 @@ Effect of DMP Gain
 
 Demonstrates how modifying DMP gains (alpha_y, beta_y) affects 
 the resulting trajectory reproduction.
-
-
 """
 
 print(__doc__)

--- a/movement_primitives/dmp/_base.py
+++ b/movement_primitives/dmp/_base.py
@@ -18,6 +18,16 @@ class DMPBase(PointToPointMovement):
 
         self.initialized = False
 
+    @staticmethod
+    def _process_gain_input(value, dim, label):
+        """Process scalar or array-like input to ensure it is a 1D numpy array of the correct shape."""        
+        value = np.atleast_1d(value).astype(float).flatten()
+        if value.shape[0] == 1:
+            value = value * np.ones(dim)
+        elif value.shape != (dim,):
+            raise ValueError(f"{label} has incorrect shape, expected ({dim},) got {value.shape}")
+        return value
+
     def reset(self):
         """Reset DMP to initial state and time."""
         self.t = 0.0

--- a/movement_primitives/dmp/_base.py
+++ b/movement_primitives/dmp/_base.py
@@ -18,16 +18,6 @@ class DMPBase(PointToPointMovement):
 
         self.initialized = False
 
-    @staticmethod
-    def _process_gain_input(value, dim, label):
-        """Process scalar or array-like input to ensure it is a 1D numpy array of the correct shape."""        
-        value = np.atleast_1d(value).astype(float).flatten()
-        if value.shape[0] == 1:
-            value = value * np.ones(dim)
-        elif value.shape != (dim,):
-            raise ValueError(f"{label} has incorrect shape, expected ({dim},) got {value.shape}")
-        return value
-
     def reset(self):
         """Reset DMP to initial state and time."""
         self.t = 0.0

--- a/movement_primitives/dmp/_cartesian_dmp.py
+++ b/movement_primitives/dmp/_cartesian_dmp.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pytransform3d.rotations as pr
+from ..utils import ensure_1d_array
 from ._base import DMPBase
 from ._forcing_term import ForcingTerm
 from ._canonical_system import canonical_system_alpha
 from ._dmp import (dmp_open_loop, dmp_imitate, ridge_regression,
                    DMP_STEP_FUNCTIONS, DEFAULT_DMP_STEP_FUNCTION, phase)
-
 
 def dmp_step_quaternion_python(
         last_t, t,
@@ -243,8 +243,8 @@ class CartesianDMP(DMPBase):
 
         self._init_forcing_term()
 
-        self.alpha_y = self._process_gain_input(alpha_y, 6, "alpha_y")
-        self.beta_y = self._process_gain_input(beta_y, 6, "beta_y")
+        self.alpha_y = ensure_1d_array(alpha_y, 6, "alpha_y")
+        self.beta_y = ensure_1d_array(beta_y, 6, "beta_y")
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_cartesian_dmp.py
+++ b/movement_primitives/dmp/_cartesian_dmp.py
@@ -243,29 +243,8 @@ class CartesianDMP(DMPBase):
 
         self._init_forcing_term()
 
-        if isinstance(alpha_y, float):
-            self.alpha_y = alpha_y * np.ones(6)
-        elif isinstance(alpha_y, (np.ndarray, list)):
-            alpha_y = np.asarray(alpha_y)
-            assert alpha_y.shape == (6,), "alpha_y must have shape (6,)"
-            self.alpha_y = alpha_y
-        else:
-            t = type(alpha_y)
-            raise ValueError(
-                f"alpha_y must be either a float or np.ndarray, not '{t}'"
-            )
-
-        if isinstance(beta_y, float):
-            self.beta_y = beta_y * np.ones(6)
-        elif isinstance(beta_y, (np.ndarray, list)):
-            beta_y = np.asarray(beta_y)
-            assert beta_y.shape == (6,), "beta_y must have shape (6,)"
-            self.beta_y = beta_y
-        else:
-            t = type(beta_y)
-            raise ValueError(
-                f"beta_y must be either a float or np.ndarray, not '{t}'"
-            )
+        self.alpha_y = self._process_gain_input(alpha_y, 6, "alpha_y")
+        self.beta_y = self._process_gain_input(beta_y, 6, "beta_y")
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_cartesian_dmp.py
+++ b/movement_primitives/dmp/_cartesian_dmp.py
@@ -125,7 +125,9 @@ def dmp_step_quaternion_python(
 
         current_ydd[:] = (
             alpha_y * (
-                beta_y * pr.compact_axis_angle_from_quaternion(pr.concatenate_quaternions(goal_y, pr.q_conj(current_y)))
+                beta_y * pr.compact_axis_angle_from_quaternion(
+                    pr.concatenate_quaternions(goal_y, pr.q_conj(current_y))
+                )
                 - execution_time * current_yd
                 - smoothing
             )
@@ -202,7 +204,7 @@ class CartesianDMP(DMPBase):
 
     alpha_y : float, list with length 6, or array with shape (6,), optional (default: 25.0)
         Parameter of the transformation system.
-    
+
     beta_y : float, list with length 6, or array with shape (6,), optional (default: 6.25)
         Parameter of the transformation system.
 
@@ -248,8 +250,11 @@ class CartesianDMP(DMPBase):
             assert alpha_y.shape == (6,), "alpha_y must have shape (6,)"
             self.alpha_y = alpha_y
         else:
-            raise ValueError(f"alpha_y must be either a float or np.ndarray, not '{type(alpha_y)}'")
-        
+            t = type(alpha_y)
+            raise ValueError(
+                f"alpha_y must be either a float or np.ndarray, not '{t}'"
+            )
+
         if isinstance(beta_y, float):
             self.beta_y = beta_y * np.ones(6)
         elif isinstance(beta_y, (np.ndarray, list)):
@@ -257,7 +262,10 @@ class CartesianDMP(DMPBase):
             assert beta_y.shape == (6,), "beta_y must have shape (6,)"
             self.beta_y = beta_y
         else:
-            raise ValueError(f"beta_y must be either a float or np.ndarray, not '{type(beta_y)}'")                
+            t = type(beta_y)
+            raise ValueError(
+                f"beta_y must be either a float or np.ndarray, not '{t}'"
+            )
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_cartesian_dmp.py
+++ b/movement_primitives/dmp/_cartesian_dmp.py
@@ -202,10 +202,10 @@ class CartesianDMP(DMPBase):
         is changed and the trajectory is scaled by interpolating between
         the old and new scaling of the trajectory.
 
-    alpha_y : float, list with length 6, or array with shape (6,), optional (default: 25.0)
+    alpha_y : float or array-like, shape (6,), optional (default: 25.0)
         Parameter of the transformation system.
 
-    beta_y : float, list with length 6, or array with shape (6,), optional (default: 6.25)
+    beta_y : float or array-like, shape (6,), optional (default: 6.25)
         Parameter of the transformation system.
 
     Attributes

--- a/movement_primitives/dmp/_dmp.py
+++ b/movement_primitives/dmp/_dmp.py
@@ -380,7 +380,7 @@ class DMP(WeightParametersMixin, DMPBase):
         is changed and the trajectory is scaled by interpolating between
         the old and new scaling of the trajectory.
 
-    alpha_y : float, list with length n_dims, or array with shape (n_dims,), optional (default: 25.0)
+    alpha_y : float or array-like, shape (n_dims,), optional (default: 25.0)
         Parameter of the transformation system.
 
     beta_y : float, list with length n_dims, or array with shape (n_dims,), optional (default: 6.25)

--- a/movement_primitives/dmp/_dmp.py
+++ b/movement_primitives/dmp/_dmp.py
@@ -808,10 +808,10 @@ def dmp_open_loop(
     dt : float, optional (default: 0.01)
         Time difference between DMP steps.
 
-    start_y : array, shape (7,)
+    start_y : array, shape (n_dims,)
         Start position.
 
-    goal_y : array, shape (7,)
+    goal_y : array, shape (n_dims,)
         Goal position.
 
     alpha_y : float

--- a/movement_primitives/dmp/_dmp.py
+++ b/movement_primitives/dmp/_dmp.py
@@ -3,6 +3,7 @@ from ._base import DMPBase, WeightParametersMixin
 from ._forcing_term import ForcingTerm
 from ._canonical_system import canonical_system_alpha
 from ._forcing_term import phase
+from ..utils import ensure_1d_array
 
 
 def dmp_step_rk4(
@@ -422,8 +423,8 @@ class DMP(WeightParametersMixin, DMPBase):
 
         self._init_forcing_term()
 
-        self.alpha_y = self._process_gain_input(alpha_y, n_dims, "alpha_y")
-        self.beta_y = self._process_gain_input(beta_y, n_dims, "beta_y")
+        self.alpha_y = ensure_1d_array(alpha_y, n_dims, "alpha_y")
+        self.beta_y = ensure_1d_array(beta_y, n_dims, "beta_y")
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_dmp.py
+++ b/movement_primitives/dmp/_dmp.py
@@ -422,31 +422,8 @@ class DMP(WeightParametersMixin, DMPBase):
 
         self._init_forcing_term()
 
-        if isinstance(alpha_y, float):
-            self.alpha_y = alpha_y * np.ones(n_dims)
-        elif isinstance(alpha_y, (np.ndarray, list)):
-            alpha_y = np.asarray(alpha_y)
-            assert alpha_y.shape == (n_dims,), \
-                f"alpha_y must have shape ({n_dims},)"
-            self.alpha_y = alpha_y
-        else:
-            t = type(alpha_y)
-            raise ValueError(
-                f"alpha_y must be either a float or np.ndarray, not '{t}'"
-            )
-
-        if isinstance(beta_y, float):
-            self.beta_y = beta_y * np.ones(n_dims)
-        elif isinstance(beta_y, (np.ndarray, list)):
-            beta_y = np.asarray(beta_y)
-            assert beta_y.shape == (n_dims,), \
-                f"beta_y must have shape ({n_dims},)"
-            self.beta_y = beta_y
-        else:
-            t = type(beta_y)
-            raise ValueError(
-                f"beta_y must be either a float or np.ndarray, not '{t}'"
-            )
+        self.alpha_y = self._process_gain_input(alpha_y, n_dims, "alpha_y")
+        self.beta_y = self._process_gain_input(beta_y, n_dims, "beta_y")
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_dmp.py
+++ b/movement_primitives/dmp/_dmp.py
@@ -382,9 +382,9 @@ class DMP(WeightParametersMixin, DMPBase):
 
     alpha_y : float, list with length n_dims, or array with shape (n_dims,), optional (default: 25.0)
         Parameter of the transformation system.
-    
+
     beta_y : float, list with length n_dims, or array with shape (n_dims,), optional (default: 6.25)
-        Parameter of the transformation system.            
+        Parameter of the transformation system.
 
     Attributes
     ----------
@@ -426,20 +426,28 @@ class DMP(WeightParametersMixin, DMPBase):
             self.alpha_y = alpha_y * np.ones(n_dims)
         elif isinstance(alpha_y, (np.ndarray, list)):
             alpha_y = np.asarray(alpha_y)
-            assert alpha_y.shape == (n_dims,), f"alpha_y must have shape ({n_dims},)"
+            assert alpha_y.shape == (n_dims,), \
+                f"alpha_y must have shape ({n_dims},)"
             self.alpha_y = alpha_y
         else:
-            raise ValueError(f"alpha_y must be either a float or np.ndarray, not '{type(alpha_y)}'")
-        
+            t = type(alpha_y)
+            raise ValueError(
+                f"alpha_y must be either a float or np.ndarray, not '{t}'"
+            )
+
         if isinstance(beta_y, float):
             self.beta_y = beta_y * np.ones(n_dims)
         elif isinstance(beta_y, (np.ndarray, list)):
             beta_y = np.asarray(beta_y)
-            assert beta_y.shape == (n_dims,), f"beta_y must have shape ({n_dims},)"
+            assert beta_y.shape == (n_dims,), \
+                f"beta_y must have shape ({n_dims},)"
             self.beta_y = beta_y
         else:
-            raise ValueError(f"beta_y must be either a float or np.ndarray, not '{type(beta_y)}'")               
-        
+            t = type(beta_y)
+            raise ValueError(
+                f"beta_y must be either a float or np.ndarray, not '{t}'"
+            )
+
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)
         self.forcing_term = ForcingTerm(
@@ -595,12 +603,15 @@ class DMP(WeightParametersMixin, DMPBase):
         allow_final_velocity : bool, optional (default: False)
             Allow a final velocity.
         """
-        self.forcing_term.weights_[:, :], start_y, _, _, goal_y, _, _ = dmp_imitate(
+        self.forcing_term.weights_[:, :], start_y, _, _, goal_y, _, _ = \
+            dmp_imitate(
             T, Y,
             n_weights_per_dim=self.n_weights_per_dim,
             regularization_coefficient=regularization_coefficient,
-            alpha_y=self.alpha_y, beta_y=self.beta_y, overlap=self.forcing_term.overlap,
-            alpha_z=self.forcing_term.alpha_z, allow_final_velocity=allow_final_velocity,
+            alpha_y=self.alpha_y, beta_y=self.beta_y,
+            overlap=self.forcing_term.overlap,
+            alpha_z=self.forcing_term.alpha_z,
+            allow_final_velocity=allow_final_velocity,
             smooth_scaling=self.smooth_scaling)
         self.configure(start_y=start_y, goal_y=goal_y)
 
@@ -773,8 +784,12 @@ def dmp_imitate(
 
     forcing_term = ForcingTerm(
         Y.shape[1], n_weights_per_dim, T[-1], T[0], overlap, alpha_z)
-    F, start_y, start_yd, start_ydd, goal_y, goal_yd, goal_ydd = determine_forces(
-        T, Y, alpha_y, beta_y, alpha_z, allow_final_velocity, smooth_scaling)
+    F, start_y, start_yd, start_ydd, goal_y, goal_yd, goal_ydd = \
+        determine_forces(
+            T, Y, alpha_y, beta_y,
+            alpha_z, allow_final_velocity,
+            smooth_scaling
+        )
     # F shape (n_steps, n_dims)
 
     X = forcing_term.design_matrix(T)  # shape (n_weights_per_dim, n_steps)

--- a/movement_primitives/dmp/_dmp_with_final_velocity.py
+++ b/movement_primitives/dmp/_dmp_with_final_velocity.py
@@ -37,9 +37,9 @@ class DMPWithFinalVelocity(WeightParametersMixin, DMPBase):
 
     alpha_y : float, list with length n_dims, or array with shape (n_dims,), optional (default: 25.0)
         Parameter of the transformation system.
-    
+
     beta_y : float, list with length n_dims, or array with shape (n_dims,), optional (default: 6.25)
-        Parameter of the transformation system.    
+        Parameter of the transformation system.
 
     Attributes
     ----------
@@ -58,7 +58,8 @@ class DMPWithFinalVelocity(WeightParametersMixin, DMPBase):
        https://www.ias.informatik.tu-darmstadt.de/uploads/Publications/Muelling_IJRR_2013.pdf
     """
     def __init__(self, n_dims, execution_time=1.0, dt=0.01,
-                 n_weights_per_dim=10, int_dt=0.001, p_gain=0.0, alpha_y=25.0, beta_y=6.25):
+                 n_weights_per_dim=10, int_dt=0.001, p_gain=0.0,
+                 alpha_y=25.0, beta_y=6.25):
         super(DMPWithFinalVelocity, self).__init__(n_dims, n_dims)
         self._execution_time = execution_time
         self.dt_ = dt
@@ -77,7 +78,7 @@ class DMPWithFinalVelocity(WeightParametersMixin, DMPBase):
             self.alpha_y = alpha_y
         else:
             raise ValueError(f"alpha_y must be either a float or np.ndarray, not '{type(alpha_y)}'")
-        
+
         if isinstance(beta_y, float):
             self.beta_y = beta_y * np.ones(n_dims)
         elif isinstance(beta_y, (np.ndarray, list)):
@@ -85,7 +86,7 @@ class DMPWithFinalVelocity(WeightParametersMixin, DMPBase):
             assert beta_y.shape == (n_dims,), f"beta_y must have shape ({n_dims},)"
             self.beta_y = beta_y
         else:
-            raise ValueError(f"beta_y must be either a float or np.ndarray, not '{type(beta_y)}'")           
+            raise ValueError(f"beta_y must be either a float or np.ndarray, not '{type(beta_y)}'")
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)
@@ -212,7 +213,8 @@ class DMPWithFinalVelocity(WeightParametersMixin, DMPBase):
         regularization_coefficient : float, optional (default: 0)
             Regularization coefficient for regression.
         """
-        self.forcing_term.weights_[:, :], start_y, start_yd, start_ydd, goal_y, goal_yd, goal_ydd = dmp_imitate(
+        self.forcing_term.weights_[:, :], start_y, start_yd, \
+            start_ydd, goal_y, goal_yd, goal_ydd = dmp_imitate(
             T, Y,
             n_weights_per_dim=self.n_weights_per_dim,
             regularization_coefficient=regularization_coefficient,

--- a/movement_primitives/dmp/_dmp_with_final_velocity.py
+++ b/movement_primitives/dmp/_dmp_with_final_velocity.py
@@ -70,23 +70,8 @@ class DMPWithFinalVelocity(WeightParametersMixin, DMPBase):
 
         self._init_forcing_term()
 
-        if isinstance(alpha_y, float):
-            self.alpha_y = alpha_y * np.ones(n_dims)
-        elif isinstance(alpha_y, (np.ndarray, list)):
-            alpha_y = np.asarray(alpha_y)
-            assert alpha_y.shape == (n_dims,), f"alpha_y must have shape ({n_dims},)"
-            self.alpha_y = alpha_y
-        else:
-            raise ValueError(f"alpha_y must be either a float or np.ndarray, not '{type(alpha_y)}'")
-
-        if isinstance(beta_y, float):
-            self.beta_y = beta_y * np.ones(n_dims)
-        elif isinstance(beta_y, (np.ndarray, list)):
-            beta_y = np.asarray(beta_y)
-            assert beta_y.shape == (n_dims,), f"beta_y must have shape ({n_dims},)"
-            self.beta_y = beta_y
-        else:
-            raise ValueError(f"beta_y must be either a float or np.ndarray, not '{type(beta_y)}'")
+        self.alpha_y = self._process_gain_input(alpha_y, n_dims, "alpha_y")
+        self.beta_y = self._process_gain_input(beta_y, n_dims, "beta_y")
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_dmp_with_final_velocity.py
+++ b/movement_primitives/dmp/_dmp_with_final_velocity.py
@@ -1,5 +1,6 @@
 import numpy as np
 from ._base import DMPBase, WeightParametersMixin
+from ..utils import ensure_1d_array
 from ._forcing_term import ForcingTerm, phase
 from ._canonical_system import canonical_system_alpha
 from ._dmp import dmp_imitate, dmp_open_loop
@@ -70,8 +71,8 @@ class DMPWithFinalVelocity(WeightParametersMixin, DMPBase):
 
         self._init_forcing_term()
 
-        self.alpha_y = self._process_gain_input(alpha_y, n_dims, "alpha_y")
-        self.beta_y = self._process_gain_input(beta_y, n_dims, "beta_y")
+        self.alpha_y = ensure_1d_array(alpha_y, n_dims, "alpha_y")
+        self.beta_y = ensure_1d_array(beta_y, n_dims, "beta_y")
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_dmp_with_final_velocity.py
+++ b/movement_primitives/dmp/_dmp_with_final_velocity.py
@@ -35,10 +35,10 @@ class DMPWithFinalVelocity(WeightParametersMixin, DMPBase):
         Gain for proportional controller of DMP tracking error.
         The domain is [0, execution_time**2/dt].
 
-    alpha_y : float, list with length n_dims, or array with shape (n_dims,), optional (default: 25.0)
+    alpha_y : float or array-like, shape (n_dims,), optional (default: 25.0)
         Parameter of the transformation system.
 
-    beta_y : float, list with length n_dims, or array with shape (n_dims,), optional (default: 6.25)
+    beta_y : float or array-like, shape (n_dims,), optional (default: 6.25)
         Parameter of the transformation system.
 
     Attributes

--- a/movement_primitives/dmp/_dual_cartesian_dmp.py
+++ b/movement_primitives/dmp/_dual_cartesian_dmp.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytransform3d.rotations as pr
 from ._base import DMPBase, WeightParametersMixin
+from ..utils import ensure_1d_array
 from ._canonical_system import canonical_system_alpha
 from ._forcing_term import ForcingTerm, phase
 from ._dmp import dmp_imitate
@@ -245,8 +246,8 @@ class DualCartesianDMP(WeightParametersMixin, DMPBase):
 
         self._init_forcing_term()
 
-        self.alpha_y = self._process_gain_input(alpha_y, 12, "alpha_y")
-        self.beta_y = self._process_gain_input(beta_y, 12, "beta_y")
+        self.alpha_y = ensure_1d_array(alpha_y, 12, "alpha_y")
+        self.beta_y = ensure_1d_array(beta_y, 12, "beta_y")
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_dual_cartesian_dmp.py
+++ b/movement_primitives/dmp/_dual_cartesian_dmp.py
@@ -206,9 +206,9 @@ class DualCartesianDMP(WeightParametersMixin, DMPBase):
 
     alpha_y : float, list with length 12, or array with shape (12,), optional (default: 25.0)
         Parameter of the transformation system.
-    
+
     beta_y : float, list with length 12, or array with shape (12,), optional (default: 6.25)
-        Parameter of the transformation system.                    
+        Parameter of the transformation system.
 
     Attributes
     ----------
@@ -252,8 +252,11 @@ class DualCartesianDMP(WeightParametersMixin, DMPBase):
             assert alpha_y.shape == (12,), "alpha_y must have shape (12,)"
             self.alpha_y = alpha_y
         else:
-            raise ValueError(f"alpha_y must be either a float or np.ndarray, not '{type(alpha_y)}'")
-        
+            t = type(alpha_y)
+            raise ValueError(
+                f"alpha_y must be either a float or np.ndarray, not '{t}'"
+            )
+
         if isinstance(beta_y, float):
             self.beta_y = beta_y * np.ones(12)
         elif isinstance(beta_y, (np.ndarray, list)):
@@ -261,7 +264,10 @@ class DualCartesianDMP(WeightParametersMixin, DMPBase):
             assert beta_y.shape == (12,), "beta_y must have shape (12,)"
             self.beta_y = beta_y
         else:
-            raise ValueError(f"beta_y must be either a float or np.ndarray, not '{type(beta_y)}'")                   
+            t = type(beta_y)
+            raise ValueError(
+                f"beta_y must be either a float or np.ndarray, not '{t}'"
+            )
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_dual_cartesian_dmp.py
+++ b/movement_primitives/dmp/_dual_cartesian_dmp.py
@@ -204,10 +204,10 @@ class DualCartesianDMP(WeightParametersMixin, DMPBase):
         is changed and the trajectory is scaled by interpolating between
         the old and new scaling of the trajectory.
 
-    alpha_y : float, list with length 12, or array with shape (12,), optional (default: 25.0)
+    alpha_y : float or array-like, shape (12,), optional (default: 25.0)
         Parameter of the transformation system.
 
-    beta_y : float, list with length 12, or array with shape (12,), optional (default: 6.25)
+    beta_y : float or array-like, shape (12,), optional (default: 6.25)
         Parameter of the transformation system.
 
     Attributes

--- a/movement_primitives/dmp/_dual_cartesian_dmp.py
+++ b/movement_primitives/dmp/_dual_cartesian_dmp.py
@@ -245,29 +245,8 @@ class DualCartesianDMP(WeightParametersMixin, DMPBase):
 
         self._init_forcing_term()
 
-        if isinstance(alpha_y, float):
-            self.alpha_y = alpha_y * np.ones(12)
-        elif isinstance(alpha_y, (np.ndarray, list)):
-            alpha_y = np.asarray(alpha_y)
-            assert alpha_y.shape == (12,), "alpha_y must have shape (12,)"
-            self.alpha_y = alpha_y
-        else:
-            t = type(alpha_y)
-            raise ValueError(
-                f"alpha_y must be either a float or np.ndarray, not '{t}'"
-            )
-
-        if isinstance(beta_y, float):
-            self.beta_y = beta_y * np.ones(12)
-        elif isinstance(beta_y, (np.ndarray, list)):
-            beta_y = np.asarray(beta_y)
-            assert beta_y.shape == (12,), "beta_y must have shape (12,)"
-            self.beta_y = beta_y
-        else:
-            t = type(beta_y)
-            raise ValueError(
-                f"beta_y must be either a float or np.ndarray, not '{t}'"
-            )
+        self.alpha_y = self._process_gain_input(alpha_y, 12, "alpha_y")
+        self.beta_y = self._process_gain_input(beta_y, 12, "beta_y")
 
     def _init_forcing_term(self):
         alpha_z = canonical_system_alpha(0.01, self.execution_time_, 0.0)

--- a/movement_primitives/dmp/_state_following_dmp.py
+++ b/movement_primitives/dmp/_state_following_dmp.py
@@ -25,7 +25,7 @@ class StateFollowingDMP(WeightParametersMixin, DMPBase):
        https://link.springer.com/chapter/10.1007/978-3-030-19648-6_32
     """
     def __init__(self, n_dims, execution_time, dt=0.01, n_viapoints=10,
-                 int_dt=0.001):
+                 int_dt=0.001, alpha_y=25.0, beta_y=6.25):
         super(StateFollowingDMP, self).__init__(n_dims, n_dims)
         self.execution_time = execution_time
         self.dt_ = dt
@@ -34,8 +34,21 @@ class StateFollowingDMP(WeightParametersMixin, DMPBase):
 
         alpha_z = canonical_system_alpha(0.01, self.execution_time, 0.0)
 
-        self.alpha_y = 25.0
-        self.beta_y = self.alpha_y / 4.0
+        if isinstance(alpha_y, float):
+            self.alpha_y = alpha_y * np.ones(n_dims)
+        elif isinstance(alpha_y, (np.ndarray, list)):
+            alpha_y = np.asarray(alpha_y)
+            assert alpha_y.shape == (n_dims,), f"alpha_y must have shape ({n_dims},)"
+            self.alpha_y = alpha_y
+        else:
+            raise ValueError(f"alpha_y must be either a float or np.ndarray, not '{type(alpha_y)}'")
+        
+        if isinstance(beta_y, float):
+            self.beta_y = beta_y * np.ones(n_dims)
+        elif isinstance(beta_y, (np.ndarray, list)):
+            beta_y = np.asarray(beta_y)
+            assert beta_y.shape == (n_dims,), f"beta_y must have shape ({n_dims},)"
+            self.beta_y = beta_y                
 
         self.forcing_term = StateFollowingForcingTerm(
             self.n_dims, self.n_viapoints, self.execution_time, 0.0, 0.1,

--- a/movement_primitives/dmp/_state_following_dmp.py
+++ b/movement_primitives/dmp/_state_following_dmp.py
@@ -34,26 +34,8 @@ class StateFollowingDMP(WeightParametersMixin, DMPBase):
 
         alpha_z = canonical_system_alpha(0.01, self.execution_time, 0.0)
 
-        if isinstance(alpha_y, float):
-            self.alpha_y = alpha_y * np.ones(n_dims)
-        elif isinstance(alpha_y, (np.ndarray, list)):
-            alpha_y = np.asarray(alpha_y)
-            assert alpha_y.shape == (n_dims,), \
-                f"alpha_y must have shape ({n_dims},)"
-            self.alpha_y = alpha_y
-        else:
-            t = type(alpha_y)
-            raise ValueError(
-                f"alpha_y must be either a float or np.ndarray, not '{t}'"
-            )
-
-        if isinstance(beta_y, float):
-            self.beta_y = beta_y * np.ones(n_dims)
-        elif isinstance(beta_y, (np.ndarray, list)):
-            beta_y = np.asarray(beta_y)
-            assert beta_y.shape == (n_dims,), \
-                f"beta_y must have shape ({n_dims},)"
-            self.beta_y = beta_y
+        self.alpha_y = self._process_gain_input(alpha_y, n_dims, "alpha_y")
+        self.beta_y = self._process_gain_input(beta_y, n_dims, "beta_y")
 
         self.forcing_term = StateFollowingForcingTerm(
             self.n_dims, self.n_viapoints, self.execution_time, 0.0, 0.1,

--- a/movement_primitives/dmp/_state_following_dmp.py
+++ b/movement_primitives/dmp/_state_following_dmp.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 from ._base import DMPBase, WeightParametersMixin
+from ..utils import ensure_1d_array
 from ._canonical_system import canonical_system_alpha, phase
 
 
@@ -34,8 +35,8 @@ class StateFollowingDMP(WeightParametersMixin, DMPBase):
 
         alpha_z = canonical_system_alpha(0.01, self.execution_time, 0.0)
 
-        self.alpha_y = self._process_gain_input(alpha_y, n_dims, "alpha_y")
-        self.beta_y = self._process_gain_input(beta_y, n_dims, "beta_y")
+        self.alpha_y = ensure_1d_array(alpha_y, n_dims, "alpha_y")
+        self.beta_y = ensure_1d_array(beta_y, n_dims, "beta_y")
 
         self.forcing_term = StateFollowingForcingTerm(
             self.n_dims, self.n_viapoints, self.execution_time, 0.0, 0.1,

--- a/movement_primitives/dmp/_state_following_dmp.py
+++ b/movement_primitives/dmp/_state_following_dmp.py
@@ -38,17 +38,22 @@ class StateFollowingDMP(WeightParametersMixin, DMPBase):
             self.alpha_y = alpha_y * np.ones(n_dims)
         elif isinstance(alpha_y, (np.ndarray, list)):
             alpha_y = np.asarray(alpha_y)
-            assert alpha_y.shape == (n_dims,), f"alpha_y must have shape ({n_dims},)"
+            assert alpha_y.shape == (n_dims,), \
+                f"alpha_y must have shape ({n_dims},)"
             self.alpha_y = alpha_y
         else:
-            raise ValueError(f"alpha_y must be either a float or np.ndarray, not '{type(alpha_y)}'")
-        
+            t = type(alpha_y)
+            raise ValueError(
+                f"alpha_y must be either a float or np.ndarray, not '{t}'"
+            )
+
         if isinstance(beta_y, float):
             self.beta_y = beta_y * np.ones(n_dims)
         elif isinstance(beta_y, (np.ndarray, list)):
             beta_y = np.asarray(beta_y)
-            assert beta_y.shape == (n_dims,), f"beta_y must have shape ({n_dims},)"
-            self.beta_y = beta_y                
+            assert beta_y.shape == (n_dims,), \
+                f"beta_y must have shape ({n_dims},)"
+            self.beta_y = beta_y
 
         self.forcing_term = StateFollowingForcingTerm(
             self.n_dims, self.n_viapoints, self.execution_time, 0.0, 0.1,

--- a/movement_primitives/dmp_fast.pyx
+++ b/movement_primitives/dmp_fast.pyx
@@ -177,13 +177,13 @@ cpdef dmp_step(
 
         for d in range(n_dims):
             if smooth_scaling:
-                smoothing = beta_y * (goal_y[d] - start_y[d]) * z
+                smoothing = beta_y[d] * (goal_y[d] - start_y[d]) * z
             else:
                 smoothing = 0.0
 
             current_ydd[d] = (
-                alpha_y * (
-                    beta_y * (goal_y[d] - current_y[d])
+                alpha_y[d] * (
+                    beta_y[d] * (goal_y[d] - current_y[d])
                     - execution_time * current_yd[d]
                     - smoothing
                 )
@@ -348,12 +348,12 @@ cdef _dmp_acc(
     cdef double smoothing
     for d in range(n_dims):
         if smooth_scaling:
-            smoothing = beta_y * (goal_y[d] - start_y[d]) * z
+            smoothing = beta_y[d] * (goal_y[d] - start_y[d]) * z
         else:
             smoothing = 0.0
         Ydd[d] = (
-            alpha_y * (
-                beta_y * (goal_y[d] - Y[d])
+            alpha_y[d] * (
+                beta_y[d] * (goal_y[d] - Y[d])
                 - execution_time * V[d]
                 - smoothing
             )
@@ -638,12 +638,12 @@ cpdef dmp_step_dual_cartesian(
         # position components
         for pps, pvs in POS_INDICES:
             if smooth_scaling:
-                smoothing_pos = beta_y * (goal_y[pps] - start_y[pps]) * z
+                smoothing_pos = beta_y[pps] * (goal_y[pps] - start_y[pps]) * z
             else:
                 smoothing_pos = 0.0
             current_ydd[pvs] = (
-                alpha_y * (
-                    beta_y * (goal_y[pps] - current_y[pps])
+                alpha_y[pvs] * (
+                    beta_y[pvs] * (goal_y[pps] - current_y[pps])
                     - execution_time * current_yd[pvs]
                     - smoothing_pos
                 )
@@ -658,10 +658,10 @@ cpdef dmp_step_dual_cartesian(
             if smooth_scaling:
                 goal_y_minus_start_y = compact_axis_angle_from_quaternion(
                     concatenate_quaternions(goal_y[ops], q_conj(start_y[ops])))
-                smoothing_orn[:] = beta_y * z * goal_y_minus_start_y
+                smoothing_orn[:] = beta_y[ovs] * z * goal_y_minus_start_y
             current_ydd[ovs] = (
-                alpha_y * (
-                    beta_y * compact_axis_angle_from_quaternion(
+                alpha_y[ovs] * (
+                    beta_y[ovs] * compact_axis_angle_from_quaternion(
                         concatenate_quaternions(goal_y[ops], q_conj(current_y[ops])))
                     - execution_time * current_yd[ovs]
                     - smoothing_orn

--- a/movement_primitives/dmp_fast.pyx
+++ b/movement_primitives/dmp_fast.pyx
@@ -53,7 +53,7 @@ cpdef dmp_step(
         np.ndarray[double, ndim=1] goal_y, np.ndarray[double, ndim=1] goal_yd,
         np.ndarray[double, ndim=1] goal_ydd, np.ndarray[double, ndim=1] start_y,
         np.ndarray[double, ndim=1] start_yd, np.ndarray[double, ndim=1] start_ydd,
-        double goal_t, double start_t, double alpha_y, double beta_y,
+        double goal_t, double start_t, np.ndarray[double, ndim=1] alpha_y, np.ndarray[double, ndim=1] beta_y,
         object forcing_term, object coupling_term=None,
         tuple coupling_term_precomputed=None,
         double int_dt=0.001, double p_gain=0.0,
@@ -99,10 +99,10 @@ cpdef dmp_step(
     start_t : float
         Time at the start.
 
-    alpha_y : float
+    alpha_y : array, shape (n_dims,)
         Constant in transformation system.
 
-    beta_y : float
+    beta_y : array, shape (n_dims,)
         Constant in transformation system.
 
     forcing_term : ForcingTerm
@@ -203,7 +203,7 @@ cpdef dmp_step_rk4(
         np.ndarray[double, ndim=1] goal_y, np.ndarray[double, ndim=1] goal_yd,
         np.ndarray[double, ndim=1] goal_ydd, np.ndarray[double, ndim=1] start_y,
         np.ndarray[double, ndim=1] start_yd, np.ndarray[double, ndim=1] start_ydd,
-        double goal_t, double start_t, double alpha_y, double beta_y,
+        double goal_t, double start_t, np.ndarray[double, ndim=1] alpha_y, np.ndarray[double, ndim=1] beta_y,
         object forcing_term, object coupling_term=None,
         tuple coupling_term_precomputed=None,
         double int_dt=0.001, double p_gain=0.0,
@@ -249,10 +249,10 @@ cpdef dmp_step_rk4(
     start_t : float
         Time at the start.
 
-    alpha_y : float
+    alpha_y : array, shape (n_dims,)
         Constant in transformation system.
 
-    beta_y : float
+    beta_y : array, shape (n_dims,)
         Constant in transformation system.
 
     forcing_term : ForcingTerm
@@ -333,7 +333,7 @@ cpdef dmp_step_rk4(
 
 cdef _dmp_acc(
         np.ndarray[double, ndim=1] Y, np.ndarray[double, ndim=1] V,
-        np.ndarray[double, ndim=1] cdd, double dt, double alpha_y, double beta_y,
+        np.ndarray[double, ndim=1] cdd, double dt, np.ndarray[double, ndim=1] alpha_y, np.ndarray[double, ndim=1] beta_y,
         np.ndarray[double, ndim=1] goal_y, np.ndarray[double, ndim=1] goal_yd,
         np.ndarray[double, ndim=1] goal_ydd, np.ndarray[double, ndim=1] start_y,
         double z, double execution_time, np.ndarray[double, ndim=1] f,
@@ -378,7 +378,7 @@ cpdef dmp_step_quaternion(
         np.ndarray[double, ndim=1] start_y,
         np.ndarray[double, ndim=1] start_yd,
         np.ndarray[double, ndim=1] start_ydd,
-        double goal_t, double start_t, double alpha_y, double beta_y,
+        double goal_t, double start_t, np.ndarray[double, ndim=1] alpha_y, np.ndarray[double, ndim=1] beta_y,
         forcing_term, coupling_term=None, coupling_term_precomputed=None,
         double int_dt=0.001, bint smooth_scaling=False):
     """Integrate quaternion DMP for one step with Euler integration.
@@ -421,10 +421,10 @@ cpdef dmp_step_quaternion(
     start_t : float
         Time at the start.
 
-    alpha_y : float
+    alpha_y : array, shape (6,)
         Constant in transformation system.
 
-    beta_y : float
+    beta_y : array, shape (6,)
         Constant in transformation system.
 
     forcing_term : ForcingTerm
@@ -514,7 +514,7 @@ cpdef dmp_step_dual_cartesian(
         np.ndarray[double, ndim=1] current_y, np.ndarray[double, ndim=1] current_yd,
         np.ndarray[double, ndim=1] goal_y, np.ndarray[double, ndim=1] goal_yd, np.ndarray[double, ndim=1] goal_ydd,
         np.ndarray[double, ndim=1] start_y, np.ndarray[double, ndim=1] start_yd, np.ndarray[double, ndim=1] start_ydd,
-        double goal_t, double start_t, double alpha_y, double beta_y,
+        double goal_t, double start_t, np.ndarray[double, ndim=1] alpha_y, np.ndarray[double, ndim=1] beta_y,
         forcing_term, coupling_term=None,
         double int_dt=0.001,
         double p_gain=0.0, np.ndarray tracking_error=None,
@@ -559,10 +559,10 @@ cpdef dmp_step_dual_cartesian(
     start_t : float
         Time at the start.
 
-    alpha_y : float
+    alpha_y : array, shape (12,)
         Constant in transformation system.
 
-    beta_y : float
+    beta_y : array, shape (12,)
         Constant in transformation system.
 
     forcing_term : ForcingTerm

--- a/movement_primitives/utils.py
+++ b/movement_primitives/utils.py
@@ -1,11 +1,11 @@
 import numpy as np
 
 
-def ensure_1d_array(value, dim, label):
+def ensure_1d_array(value, n_dims, var_name):
     """Process scalar or array-like input to ensure it is a 1D numpy array of the correct shape."""
     value = np.atleast_1d(value).astype(float).flatten()
     if value.shape[0] == 1:
-        value = value * np.ones(dim)
-    elif value.shape != (dim,):
-        raise ValueError(f"{label} has incorrect shape, expected ({dim},) got {value.shape}")
+        value = value * np.ones(n_dims)
+    elif value.shape != (n_dims,):
+        raise ValueError(f"{var_name} has incorrect shape, expected ({n_dims},) got {value.shape}")
     return value

--- a/movement_primitives/utils.py
+++ b/movement_primitives/utils.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+
+def ensure_1d_array(value, dim, label):
+    """Process scalar or array-like input to ensure it is a 1D numpy array of the correct shape."""
+    value = np.atleast_1d(value).astype(float).flatten()
+    if value.shape[0] == 1:
+        value = value * np.ones(dim)
+    elif value.shape != (dim,):
+        raise ValueError(f"{label} has incorrect shape, expected ({dim},) got {value.shape}")
+    return value

--- a/test/test_cartesian_dmp.py
+++ b/test/test_cartesian_dmp.py
@@ -75,7 +75,7 @@ def test_compare_python_cython():
         current_y=np.array([1.0, 0.0, 0.0, 0.0]), current_yd=np.zeros([3]),
         goal_y=np.array([1.0, 0.0, 0.0, 0.0]), goal_yd=np.zeros([3]), goal_ydd=np.zeros([3]),
         start_y=np.array([1.0, 0.0, 0.0, 0.0]), start_yd=np.zeros([3]), start_ydd=np.zeros([3]),
-        goal_t=2.0, start_t=0.0, alpha_y=25.0, beta_y=6.25,
+        goal_t=2.0, start_t=0.0, alpha_y=25.0*np.ones(3), beta_y=6.25*np.ones(3),
         forcing_term=forcing_term, coupling_term=None, int_dt=0.0001
     )
     kwargs_python = deepcopy(kwargs)

--- a/test/test_cartesian_dmp.py
+++ b/test/test_cartesian_dmp.py
@@ -75,7 +75,7 @@ def test_compare_python_cython():
         current_y=np.array([1.0, 0.0, 0.0, 0.0]), current_yd=np.zeros([3]),
         goal_y=np.array([1.0, 0.0, 0.0, 0.0]), goal_yd=np.zeros([3]), goal_ydd=np.zeros([3]),
         start_y=np.array([1.0, 0.0, 0.0, 0.0]), start_yd=np.zeros([3]), start_ydd=np.zeros([3]),
-        goal_t=2.0, start_t=0.0, alpha_y=25.0*np.ones(3), beta_y=6.25*np.ones(3),
+        goal_t=2.0, start_t=0.0, alpha_y=25.0 * np.ones(3), beta_y=6.25 * np.ones(3),
         forcing_term=forcing_term, coupling_term=None, int_dt=0.0001
     )
     kwargs_python = deepcopy(kwargs)

--- a/test/test_step_dual_cartesian.py
+++ b/test/test_step_dual_cartesian.py
@@ -18,7 +18,9 @@ def test_compare_python_cython():
         goal_yd=np.zeros([12]), goal_ydd=np.zeros([12]),
         start_y=np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]),
         start_yd=np.zeros([12]), start_ydd=np.zeros([12]),
-        goal_t=2.0, start_t=0.0, alpha_y=25.0, beta_y=6.25,
+        goal_t=2.0, start_t=0.0, 
+        alpha_y=25.0 * np.ones(12), 
+        beta_y=6.25 * np.ones(12),
         forcing_term=forcing_term, coupling_term=None, int_dt=0.0001,
         p_gain=0.0, tracking_error=None
     )


### PR DESCRIPTION
Exposes `alpha_y` and `beta_y` to all DMP constructors and enables vectorization while maintaining backward compatibility with scalar values. 

Addresses #57.

**Are there unit tests?**

Unit tests are updated to handle new features. Pytest going green.

**Does it have docstrings?**

Docstrings have been updated where appropriate.

**Is it included in the API documentation?**

NA

**Run flake8 and pylint**

Done

**Should it be part of the readme?**

No

**Should it be included in any example script?**

Not necessarily.
