### PR TITLE
Fix author name in citations

### DIFF
--- a/movement_primitives/dmp/_cartesian_dmp.py
+++ b/movement_primitives/dmp/_cartesian_dmp.py
@@ -219,7 +219,7 @@ class CartesianDMP(DMPBase):
 
     References
     ----------
-    .. [1] Ude, A., Nemec, B., Petric, T., Murimoto, J. (2014).
+    .. [1] Ude, A., Nemec, B., Petric, T., Morimoto, J. (2014).
        Orientation in Cartesian space dynamic movement primitives.
        In IEEE International Conference on Robotics and Automation (ICRA)
        (pp. 2997-3004). DOI: 10.1109/ICRA.2014.6907291,

--- a/movement_primitives/dmp/_dual_cartesian_dmp.py
+++ b/movement_primitives/dmp/_dual_cartesian_dmp.py
@@ -222,7 +222,7 @@ class DualCartesianDMP(WeightParametersMixin, DMPBase):
 
     References
     ----------
-    .. [1] Ude, A., Nemec, B., Petric, T., Murimoto, J. (2014).
+    .. [1] Ude, A., Nemec, B., Petric, T., Morimoto, J. (2014).
        Orientation in Cartesian space dynamic movement primitives.
        In IEEE International Conference on Robotics and Automation (ICRA)
        (pp. 2997-3004). DOI: 10.1109/ICRA.2014.6907291,


### PR DESCRIPTION
Fix author's name in citation (it's strange for Japanese)

FYI: according to google scholar
``` 
@inproceedings{ude2014orientation,
  title={Orientation in cartesian space dynamic movement primitives},
  author={Ude, Ale{\v{s}} and Nemec, Bojan and Petri{\'c}, Tadej and Morimoto, Jun},
  booktitle={2014 IEEE International Conference on Robotics and Automation (ICRA)},
  pages={2997--3004},
  year={2014},
  organization={IEEE}
}
```