### PR TITLE
Condition a ProMP on several via-points

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.10"]
+        python-version: ["3.7", "3.8", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.10", "3.11"]
+        python-version: [3.8", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8", "3.10", "3.11"]
+        python-version: ["3.8", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__
 .coverage
 .ipynb_checkpoints/
 /cover/
+.venv/

--- a/movement_primitives/dmp_fast.pyx
+++ b/movement_primitives/dmp_fast.pyx
@@ -611,7 +611,7 @@ cpdef dmp_step_dual_cartesian(
     cdef int pps
     cdef int pvs
     cdef np.ndarray[long, ndim=2] POS_INDICES = np.array(
-        [[0, 0], [1, 1], [2, 2], [7, 6], [8, 7], [9, 8]], dtype=long)
+        [[0, 0], [1, 1], [2, 2], [7, 6], [8, 7], [9, 8]], dtype=int)
 
     cdef double dt
     cdef double current_t = last_t

--- a/movement_primitives/promp.py
+++ b/movement_primitives/promp.py
@@ -630,3 +630,48 @@ def _nd_block_diagonal(partial_1d, n_dims):
         full_nd[n_block_rows * j:n_block_rows * (j + 1),
                 n_block_cols * j:n_block_cols * (j + 1)] = partial_1d
     return full_nd
+
+
+def via_points(promp, ts, y_cond, y_conditional_cov=None):
+    """Condition ProMP on several via-points.
+
+    For details, see section 2.2 on page 4 of [1]_
+
+    Parameters
+    ----------
+    promp : ProMP instance
+
+    ts : array, shape (n_positions,)
+        Time vector at which the activations of RBFs will be queried. Note that
+        we internally normalize the time so that t_max == 1.
+
+    y_cond : array, shape (n_positions,)
+        Desired mean position vector corresponding to each time in `ts`.
+
+    y_conditional_cov : array, shape (n_dims, n_dims), optional (default: 0)
+        Covariances of desired positions.
+
+    Returns
+    -------
+    conditional_promp : ProMP
+        New conditional ProMP
+
+    References
+    ----------
+    .. [1] Paraschos, A., Daniel, C., Peters, J., Neumann, G. (2013).
+       Probabilistic movement primitives, In C.J. Burges and L. Bottou and
+       M. Welling and Z. Ghahramani and K.Q. Weinberger (Eds.), Advances in
+       Neural Information Processing Systems, 26,
+       https://papers.nips.cc/paper/2013/file/e53a0a2978c28872a4505bdb51db06dc-Paper.pdf
+    """
+    if y_conditional_cov is None:
+        y_conditional_cov = np.zeros(y_cond.shape)
+
+    for idx, t_i in enumerate(ts):
+        promp = promp.condition_position(
+            y_mean=y_cond[idx],
+            y_cov=y_conditional_cov[[idx]],
+            t=t_i,
+            t_max=1.0
+        )
+    return promp

--- a/test/test_conditional_promps.py
+++ b/test/test_conditional_promps.py
@@ -1,6 +1,6 @@
 import numpy as np
 from movement_primitives.data import generate_1d_trajectory_distribution
-from movement_primitives.promp import ProMP
+from movement_primitives.promp import ProMP, via_points
 from numpy.testing import assert_array_almost_equal
 import pytest
 
@@ -41,3 +41,35 @@ def test_conditioning_with_default_value():
     assert Y_cmean[0, 0] == pytest.approx(0.0)
     Y_cvar = cpromp.var_trajectory(T)
     assert Y_cvar[0, 0] == pytest.approx(0)
+
+
+def test_multi_via_points():
+    n_demos = 100
+    n_steps = 101
+    T, Y = generate_1d_trajectory_distribution(n_demos, n_steps)
+    promp = ProMP(n_dims=1, n_weights_per_dim=50)
+    promp.imitate([T] * n_demos, Y)
+    Y_mean = promp.mean_trajectory(T)
+    Y_var = promp.var_trajectory(T)
+    assert_array_almost_equal(Y_mean, np.mean(Y, axis=0), decimal=3)
+    assert Y_var[0] > 0
+
+    y_cond = np.array([-1, 2.5, 4, 7])
+    y_conditional_cov = np.zeros(4)
+    ts = np.array([0.0, 0.3, 0.7, 1.0])
+    idx = np.array([
+        np.argwhere(T==ts[0]).squeeze(),
+        np.argwhere(T==ts[1]).squeeze(),
+        np.argwhere(np.logical_and(T>ts[2] - 0.001, T<ts[2]+0.001)).squeeze(),
+        np.argwhere(T==ts[-1]).squeeze()
+    ])
+    cpromp = via_points(
+        promp=promp,
+        y_cond=y_cond,
+        y_conditional_cov=y_conditional_cov,
+        ts=ts
+    )
+    Y_cmean = cpromp.mean_trajectory(T)
+    assert Y_cmean[idx].squeeze() == pytest.approx(y_cond)
+    Y_cvar = cpromp.var_trajectory(T)
+    assert Y_cvar[idx] == pytest.approx(0)


### PR DESCRIPTION
This PR adds a convenience function to condition a ProMP on several via-points, as discussed in https://github.com/dfki-ric/movement_primitives/discussions/71.

Also, the CI was failing, I think because Python 3.7 is EOL, so I removed it, and added Python 3.11 instead. And there was another CI issue I had to fix, related to some Cython type that has been deprecated.