### PR TITLE
Fixed y-axis computation error in panel_pose

### DIFF
--- a/examples/external_dependencies/sim_solar_panel.py
+++ b/examples/external_dependencies/sim_solar_panel.py
@@ -13,7 +13,7 @@ def panel_pose(tcp_left, tcp_right):
     tcp_right_pos = tcp_right[:3, 3]
     tcp_middle = 0.5 * (tcp_left_pos + tcp_right_pos)
     x_axis = pr.norm_vector(tcp_right_pos - tcp_left_pos)
-    y_axis = -pr.norm_vector(0.5 * (tcp_left[:3, 1] + tcp_right[:3, 1]))
+    y_axis = -pr.norm_vector(0.5 * (tcp_left[:3, 2] + tcp_right[:3, 2]))
     R_panel = pr.matrix_from_two_vectors(x_axis, y_axis)
     return pt.transform_from(R_panel, tcp_middle)
 

--- a/examples/external_dependencies/vis_solar_panel.py
+++ b/examples/external_dependencies/vis_solar_panel.py
@@ -18,7 +18,7 @@ def panel_pose(tm):
     tcp_right_pos = tcp_right[:3, 3]
     tcp_middle = 0.5 * (tcp_left_pos + tcp_right_pos)
     x_axis = pr.norm_vector(tcp_right_pos - tcp_left_pos)
-    y_axis = -pr.norm_vector(0.5 * (tcp_left[:3, 1] + tcp_right[:3, 1]))
+    y_axis = -pr.norm_vector(0.5 * (tcp_left[:3, 2] + tcp_right[:3, 2]))
     R_panel = pr.matrix_from_two_vectors(x_axis, y_axis)
     return pt.transform_from(R_panel, tcp_middle)
 


### PR DESCRIPTION
In the panel_pose calculation, the positive direction of the y-axis of tcp_right (in the base coordinates) is the x-axis of the panel; the negative direction of the z-axis of tcp_left and tcp_right (in the base coordinates) is the y-axis of the panel.
Therefore, the y-axis calculation here should be
`y_axis = -pr.norm_vector(0.5 * (tcp_left[:3, 2] + tcp_right[:3, 2]))`
rather than
`y_axis = -pr.norm_vector(0.5 * (tcp_left[:3, 1] + tcp_right[:3, 1]))`
This is simply because the result happens to be correct in this case.
In the sim_solar_panel_rh5v2 example, the calculation result is correct.

![Snipaste_2025-06-18_20-01-08](https://github.com/user-attachments/assets/e95fbde2-0e4a-4304-8b5c-dbf1c0be3a1d)