### PR TITLE
Fixed time desynchronization in DMP

### DIFF
--- a/examples/plot_cartesian_pose_coupling_dual_dmp.py
+++ b/examples/plot_cartesian_pose_coupling_dual_dmp.py
@@ -56,7 +56,7 @@ R_to_center_start = pr.matrix_from_axis_angle([1, 0, 0, np.deg2rad(0)])
 R_to_center_end = pr.matrix_from_axis_angle([1, 0, 0, np.deg2rad(-110)])
 q_start = pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_start))
 q_end = -pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_end))
-for i, t in enumerate(T):
+for i, t in enumerate(sigmoid):
     Y[i, 3:7] = pr.quaternion_slerp(q_start, q_end, t)
 
 circle1 = radius * np.cos(np.deg2rad(270) + np.deg2rad(90) * sigmoid)
@@ -69,7 +69,7 @@ R_to_center_start = pr.matrix_from_axis_angle([1, 0, 0, np.deg2rad(-180)])
 R_to_center_end = pr.matrix_from_axis_angle([1, 0, 0, np.deg2rad(-270)])
 q_start = pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_start))
 q_end = pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_end))
-for i, t in enumerate(T):
+for i, t in enumerate(sigmoid):
     Y[i, 10:] = pr.quaternion_slerp(q_start, q_end, t)
 
 tm = UrdfTransformManager()

--- a/test/test_cartesian_pose_coupling_dual_dmp.py
+++ b/test/test_cartesian_pose_coupling_dual_dmp.py
@@ -37,7 +37,7 @@ def test_pose_coupling():
     R_to_center_end = pr.matrix_from_axis_angle([1, 0, 0, np.deg2rad(-110)])
     q_start = pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_start))
     q_end = -pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_end))
-    for i, t in enumerate(T):
+    for i, t in enumerate(sigmoid):
         Y[i, 3:7] = pr.quaternion_slerp(q_start, q_end, t)
 
     circle1 = radius * np.cos(np.deg2rad(270) + np.deg2rad(90) * sigmoid)
@@ -50,7 +50,7 @@ def test_pose_coupling():
     R_to_center_end = pr.matrix_from_axis_angle([1, 0, 0, np.deg2rad(-270)])
     q_start = pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_start))
     q_end = pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_end))
-    for i, t in enumerate(T):
+    for i, t in enumerate(sigmoid):
         Y[i, 10:] = pr.quaternion_slerp(q_start, q_end, t)
 
     dmp = DualCartesianDMP(

--- a/test/test_cartesian_pose_coupling_dual_dmp.py
+++ b/test/test_cartesian_pose_coupling_dual_dmp.py
@@ -64,8 +64,8 @@ def test_pose_coupling():
     right2left_mean = np.mean(right2left, axis=0)
     right2left_mean[:3, :3] = pr.norm_matrix(right2left_mean[:3, :3])
     pose_error = np.dot(right2left_mean, np.linalg.inv(desired_distance))
-    assert np.linalg.norm(pose_error[:3, 3]) > 0.25
-    assert pr.axis_angle_from_matrix(pose_error[:3, :3])[-1] > 0.25
+    assert np.linalg.norm(pose_error[:3, 3]) > 0.18
+    assert pr.axis_angle_from_matrix(pose_error[:3, :3])[-1] > 0.18
 
     coupling_term_pose = CouplingTermDualCartesianPose(
         desired_distance=desired_distance, couple_position=True,

--- a/test/test_coupling.py
+++ b/test/test_coupling.py
@@ -90,7 +90,7 @@ def test_coupling_term_dual_cartesian_pose():
     R_to_center_end = pr.matrix_from_axis_angle([1, 0, 0, np.deg2rad(-110)])
     q_start = pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_start))
     q_end = -pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_end))
-    for i, t in enumerate(T_demo):
+    for i, t in enumerate(sigmoid):
         Y_demo[i, 3:7] = pr.quaternion_slerp(q_start, q_end, t)
 
     circle1 = radius * np.cos(np.deg2rad(270) + np.deg2rad(90) * sigmoid)
@@ -103,7 +103,7 @@ def test_coupling_term_dual_cartesian_pose():
     R_to_center_end = pr.matrix_from_axis_angle([1, 0, 0, np.deg2rad(-270)])
     q_start = pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_start))
     q_end = pr.quaternion_from_matrix(R_three_fingers_front.dot(R_to_center_end))
-    for i, t in enumerate(T_demo):
+    for i, t in enumerate(sigmoid):
         Y_demo[i, 10:] = pr.quaternion_slerp(q_start, q_end, t)
 
     dmp = DualCartesianDMP(


### PR DESCRIPTION
The DMP position and orientation time should be synchronized, and the quaternion orientation should also use the new sigmoid time series. Otherwise, the position will move faster than the orientation, causing abnormal protrusions on the trajectory.
The figure below shows the difference between unsynchronized and synchronized trajectories.
![Snipaste_2025-06-18_21-12-50](https://github.com/user-attachments/assets/6d3aec19-201d-4bd8-8fcc-090cfcf431be)
![Snipaste_2025-06-18_21-13-59](https://github.com/user-attachments/assets/0a69024e-f3cd-4b57-a151-fc8ee97305c7)
